### PR TITLE
CSS and chart percentage

### DIFF
--- a/src/assets/styles/components/chart.scss
+++ b/src/assets/styles/components/chart.scss
@@ -7,6 +7,8 @@
     &__text {
         font-size: 12px;
         font-weight: 500;
+        // Disabled for now 
+        display: none;
     }
 
 }

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -126,11 +126,11 @@ header {
             margin-left: 30px;
 
             @media (max-width: $width-laptop) {
-                margin-left: 50px * $k-laptop;
+                margin-left: 30px * $k-laptop;
             }
 
             @media (max-width: $width-tablet) {
-                margin-left: 50px * $k-tablet;
+                margin-left: 30px * $k-tablet;
             }
         }
     }

--- a/src/pages/Home/components/CoinsInfo/CoinsInfo.tsx
+++ b/src/pages/Home/components/CoinsInfo/CoinsInfo.tsx
@@ -68,7 +68,7 @@ export class CoinsInfo extends Component<any, any> {
                     <div className="coin-prop-right">
                         <div className="coin-prop__title">Current Ratio</div>
                         <div className="coin-prop-right__value">
-                        <span>1 ERG ≈ {(1 / this.state.scPrice).toFixed(5)} {usdAcronym}</span>
+                        <span>1 ERG ≈ {(1 / this.state.scPrice).toFixed(2)} {usdAcronym}</span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Disabled the % as it works without it (and looks better)

Small padding fixes, and rounded the ratio more (figured doesn't really matter if it's 2.33 or 2.330000228 sigUSD to ERG