### PR TITLE
fix redundant calls to refresh wallet

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import CoinsInfo from './components/CoinsInfo/CoinsInfo';
 import PersonalInfo from './components/PersonalInfo/PersonalInfo';
@@ -14,7 +14,7 @@ const Home = () => {
     const [reserveVal, setReserveVal] = useState(0);
     const [stableVal, setStableVal] = useState(0);
 
-    async function updateParams() {
+    const updateParams = useCallback(async () => {
         if (isWalletSaved()) {
             const bal = await getBalanceFor(getWalletAddress());
             const ageBal = (await scBalance(bal)) / 100;
@@ -28,12 +28,15 @@ const Home = () => {
             setStableVal(ageBal);
             setErgVal(ergBal);
         }
-    }
+    }, []);
 
-    setInterval(() => {
+    useEffect(() => {
+        const id = setInterval(updateParams, 30000);
         updateParams();
-    }, 30000);
-    updateParams();
+        return () => {
+            clearInterval(id);
+        };
+    }, [updateParams]);
 
     return (
         <>


### PR DESCRIPTION
# Issue
The wallet is being refreshed redundantly every 30 seconds because the `setinterval` is being initialized multiple times.

## Steps to Reproduce:
1. navigate to sigmausd.io
1. ensure wallet is set in header
1. open browser "network" tab inside dev tools
1. note traffic to `https://api.ergoplatform.com/api/v0/addresses/xxx` occurs multiple (3x) times each interval (30s). See image:
![network-traffic](https://user-images.githubusercontent.com/3629629/115966803-35217b80-a4fd-11eb-9dd4-ef946385f995.png)

# Fix
The fix to `Homepage.tsx` puts the `setInterval` call inside a `useEffect` so that re-renders do not initialize another interval.

## Test
1. can manually confirm by running reproduction steps and noting only a single network call to the address occurs every interval
