### PR TITLE
saving commit as build version

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "REACT_APP_COMMIT=`git rev-parse HEAD` react-app-rewired build",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
     =========================================================
     * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
     -->
-
+    <meta name="build-version" content="%REACT_APP_COMMIT%" />
 </head>
 <body>
 <noscript>


### PR DESCRIPTION
recording current git commit hash at build time so you know what version the live deployment corresponds to