### PR TITLE
added skeleton

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19053,6 +19053,14 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loading-skeleton": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/react-loading-skeleton/-/react-loading-skeleton-2.2.0.tgz",
+      "integrity": "sha512-HH37uj9aobrUJSqFglHqO9KQt5zGQe+Svutv8LIq7Iq6gpJqCwIzJOsEVfkQy7ReirbI2uLhCtKloBGQIDP0BQ==",
+      "requires": {
+        "@emotion/core": "^10.0.22"
+      }
+    },
     "react-metismenu": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/react-metismenu/-/react-metismenu-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-google-maps": "^9.4.5",
     "react-hamburgers": "^1.0.0",
     "react-i18next": "^11.8.13",
+    "react-loading-skeleton": "^2.2.0",
     "react-metismenu": "^1.4.0",
     "react-motion": "^0.5.2",
     "react-perfect-scrollbar": "^1.4.4",

--- a/src/assets/styles/index.scss
+++ b/src/assets/styles/index.scss
@@ -182,3 +182,8 @@ li {
         background: none !important;
     }
 }
+
+.main-container .react-loading-skeleton {
+  background-color: var(--darkerBlack);
+  background-image: linear-gradient(90deg, var(--darkerBlack), var(--grayLight), var(--darkerBlack));
+}

--- a/src/pages/Home/components/CoinsInfo/CoinsInfo.tsx
+++ b/src/pages/Home/components/CoinsInfo/CoinsInfo.tsx
@@ -1,30 +1,40 @@
 import React, { Component } from 'react';
 import { reserveAcronym, usdAcronym } from 'utils/consts';
+import Skeleton from 'react-loading-skeleton';
+
 import { currentReserveRatio, rcNumCirc, rcPrice, scNumCirc, scPrice } from '../../../../utils/ageHelper';
 import { numberWithCommas } from '../../../../utils/serializer';
 import { withTranslation, Trans } from 'react-i18next';
 
-export class CoinsInfo extends Component<any, any> {
-    constructor(props: any) {
+type CoinsInfoProps = {};
+
+type CoinsInfoState = {
+    scPrice?: number,
+    scPriceFormatted?: string,
+    rcPrice?: number,
+    rcPriceFormatted?: string;
+    scCirc?: string,
+    rcCirc?: number,
+    reserveRatio?: number,
+};
+
+export class CoinsInfo extends Component<CoinsInfoProps, CoinsInfoState> {
+    constructor(props: CoinsInfoProps) {
         super(props);
-        this.state = {
-            scPrice: NaN,
-            rcPrice: NaN,
-            scCirc: NaN,
-            rcCirc: NaN,
-            reserveRatio: NaN,
-        };
+        this.state = {};
     }
 
     async updateParams() {
-        const sc = await scPrice();
-        const rc = await rcPrice();
-        const scCirc = await scNumCirc();
+        const sc = (await scPrice()) / 1e7;
+        const rc = (await rcPrice()) / 1e9;
+        const scCirc = (await scNumCirc()) / 100;
         const rcCirc = await rcNumCirc();
         this.setState({
-            scPrice: (sc / 1e7).toFixed(8),
-            rcPrice: (rc / 1e9).toFixed(8),
-            scCirc: (scCirc / 100).toFixed(2),
+            scPrice: sc,
+            scPriceFormatted: sc.toFixed(8),
+            rcPrice: rc,
+            rcPriceFormatted: rc.toFixed(8),
+            scCirc: scCirc.toFixed(2),
             reserveRatio: currentReserveRatio(),
             rcCirc,
         });
@@ -47,23 +57,24 @@ export class CoinsInfo extends Component<any, any> {
                         <div className="coin-prop__title"><Trans i18nKey='currentPrice' /></div>
 
                         <div className="coin-prop__value">
-                            ERG {this.state.scPrice}
-                            <span className="tooltip">
+                            ERG {this.state.scPriceFormatted || <Skeleton />}
+                            {this.state.scPrice && <span className="tooltip">
                                 <div className="tooltip__pin">?</div>
                                 <div className="tooltip__popup">
                                     <Trans i18nKey="stableHelp"
-                                           values={{ 'usdAcronym': usdAcronym, 'ratio': (1 / this.state.scPrice).toFixed(5) }}
-                                           components={{ span: <span /> }}
+                                        values={{ 'usdAcronym': usdAcronym, 'ratio': (1 / this.state.scPrice).toFixed(5) }}
+                                        components={{ span: <span /> }}
                                     />
                                 </div>
                             </span>
+                            }
                         </div>
                     </div>
 
                     <div className="coin-prop">
                         <div className="coin-prop__title"><Trans i18nKey='circulatingSupply' /></div>
                         <div className="coin-prop__value">
-                            {numberWithCommas(this.state.scCirc)}
+                            {this.state.scCirc && numberWithCommas(this.state.scCirc) || <Skeleton width={256} />}
                         </div>
                     </div>
 
@@ -72,7 +83,7 @@ export class CoinsInfo extends Component<any, any> {
                             <div className="coin-prop__title"><Trans i18nKey='currentRatio' /></div>
                             <div className="coin-prop-right__value">
                                 <span>
-                                    1 ERG ≈ {(1 / this.state.scPrice).toFixed(2)} {usdAcronym}
+                                    1 ERG ≈ {this.state.scPrice && (1 / this.state.scPrice).toFixed(2) || <Skeleton width={32} />} {usdAcronym}
                                 </span>
                             </div>
                         </div>
@@ -86,16 +97,16 @@ export class CoinsInfo extends Component<any, any> {
                         <div className="coin-prop__title"><Trans i18nKey='currentPrice' /></div>
 
                         <div className="coin-prop__value">
-                            ERG {this.state.rcPrice}
-                            <span className="tooltip">
+                            ERG {this.state.rcPriceFormatted || <Skeleton />}
+                            {this.state.rcPrice && <span className="tooltip">
                                 <div className="tooltip__pin">?</div>
                                 <div className="tooltip__popup">
                                     <Trans i18nKey='reserveHelp'
-                                           values={{ 'reserveAcronym': reserveAcronym, 'ratio': (1 / this.state.rcPrice).toFixed(0) }}
-                                           components={{ span: <span /> }}
+                                        values={{ 'reserveAcronym': reserveAcronym, 'ratio': (1 / this.state.rcPrice).toFixed(0) }}
+                                        components={{ span: <span /> }}
                                     />
                                 </div>
-                            </span>
+                            </span>}
                         </div>
                     </div>
 
@@ -103,7 +114,7 @@ export class CoinsInfo extends Component<any, any> {
                         <div className="coin-prop__title"><Trans i18nKey='circulatingSupply' /></div>
 
                         <div className="coin-prop__value">
-                            {numberWithCommas(this.state.rcCirc)}
+                            {this.state.rcCirc && numberWithCommas(this.state.rcCirc) || <Skeleton width={256} />}
                         </div>
                     </div>
 
@@ -112,7 +123,7 @@ export class CoinsInfo extends Component<any, any> {
                             <div className="coin-prop__title"><Trans i18nKey='currentRatio' /></div>
                             <div className="coin-prop-right__value">
                                 <span>
-                                    1 ERG ≈ {(1 / this.state.rcPrice).toFixed(0)} {reserveAcronym}
+                                    1 ERG ≈ {this.state.rcPrice && (1 / this.state.rcPrice).toFixed(0) || <Skeleton width={32} />} {reserveAcronym}
                                 </span>
                             </div>
                         </div>
@@ -120,7 +131,7 @@ export class CoinsInfo extends Component<any, any> {
                         <div className="coin-prop-right">
                             <div className="coin-prop-right__title"><Trans i18nKey="reserveRatio" /></div>
                             <div className="coin-prop-right__value">
-                                <span>{this.state.reserveRatio}%</span>
+                                <span>{this.state.reserveRatio || <Skeleton width={32} />}%</span>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
I find it kind of jarring on first load (that occasionally takes a second or two) when you are initially presented with the `NaN` values. It is probably extra confusing to people not familiar with `NaN` meaing "not a number" and its use as a pre-load placeholder.

This PR adds "loading skeletons" (via [react-loading-skeletons](https://github.com/dvtng/react-loading-skeleton)) to the `CoinInfo` section on the main dashboard page. There are other places where loading occurs (like the wallet balances) that I held off doing in case this approach isn't accepted.

See image below (this screen cap came out grainy for some reason):
![skeleton](https://user-images.githubusercontent.com/3629629/120085989-c8287500-c0aa-11eb-9cf9-b84ba7da2191.gif)

Side note: what are people's thoughts on using [StorybookJS](https://storybook.js.org) and the [Chromatic](https://chromatic.com) service? I've found it very useful for demonstrating UI prototypes (like this PR).  I could add storybook, but I think the chromatic setup would have to be done by the repo owner.
