### PR TITLE
add version query param to i18n URL

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -30,10 +30,11 @@ i18n
         },
         backend: {
             loadPath: (lng, ns) => {
+                const version = document.querySelector('meta[name="build-version"]')?.content;
                 if (isYamlTranslation(ns[0])) {
-                    return `/locales/${lng}/${ns}.yaml`
+                    return `/locales/${lng}/${ns}.yaml?v=${version}`
                 } else {
-                    return `/locales/${lng}/${ns}.json`
+                    return `/locales/${lng}/${ns}.json?v=${version}`
                 }
             },
             parse: (data, lng, ns) => {


### PR DESCRIPTION
The i18n files seem to be caching, so I added the `build-version` as a query param to the URL