### PR TITLE
adds loading skeletons to personal info

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -14,9 +14,9 @@ import Footer from 'components/Footer/Footer';
 import { Navigation } from 'components/Navigation/Navigation';
 
 const Home = () => {
-    const [ergVal, setErgVal] = useState(0);
-    const [reserveVal, setReserveVal] = useState(0);
-    const [stableVal, setStableVal] = useState(0);
+    const [ergVal, setErgVal] = useState<number | undefined>(undefined);
+    const [reserveVal, setReserveVal] = useState<number | undefined>(undefined);
+    const [stableVal, setStableVal] = useState<number | undefined>(undefined);
 
     const updateParams = useCallback(async () => {
         if (isWalletSaved()) {
@@ -77,7 +77,7 @@ const Home = () => {
 
                 <CoinsInfo />
                 <ReserveInfo />
-                <PersonalInfo ergVal={ergVal} stableVal={stableVal} reserveVal={reserveVal} />
+                { isWalletSaved() && <PersonalInfo ergVal={ergVal} stableVal={stableVal} reserveVal={reserveVal} /> }
 
                 <Footer />
 

--- a/src/pages/Home/components/PersonalInfo/PersonalInfo.tsx
+++ b/src/pages/Home/components/PersonalInfo/PersonalInfo.tsx
@@ -5,6 +5,7 @@ import PieChartComponent, { COLORS, COLORSIDS } from './PieChart';
 import { reserveAcronym, usdAcronym } from '../../../../utils/consts';
 import { getForKey } from '../../../../utils/helpers';
 import { Trans, withTranslation } from 'react-i18next';
+import Skeleton from 'react-loading-skeleton';
 
 interface Props {
     ergVal?: number;
@@ -161,17 +162,17 @@ export class PersonalInfo extends Component<Props, State> {
         const chartData = [
             {
                 name: usdAcronym,
-                key: 'SigmaUSD',
+                key: COLORSIDS.SIGMAUSD,
                 value: this.state.stableVal,
             },
             {
                 name: reserveAcronym,
-                key: 'SigmaRSV',
+                key: COLORSIDS.SIGMARSV,
                 value: this.state.reserveVal,
             },
             {
                 name: 'ERG',
-                key: 'Ergo',
+                key: COLORSIDS.ERGO,
                 value: this.state.ergVal,
             },
         ];
@@ -189,13 +190,13 @@ export class PersonalInfo extends Component<Props, State> {
                                     <span
                                         className="coin-title"
                                         style={{
-                                            color: COLORS[key as COLORSIDS],
+                                            color: COLORS[key],
                                         }}
                                     >
                                         {name}
                                     </span>
                                     <span className="coin-value">
-                                        ${value?.toFixed(3)}
+                                        {value !== undefined ? <>${value.toFixed(3)}</> : <>$ <Skeleton width={40} /></>}
                                     </span>
                                 </div>
                             ))}

--- a/src/pages/Home/components/PersonalInfo/PieChart.tsx
+++ b/src/pages/Home/components/PersonalInfo/PieChart.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { Cell, Pie, PieChart, ResponsiveContainer } from 'recharts';
 import { Trans } from 'react-i18next';
+import Skeleton from 'react-loading-skeleton';
 
+
+type DataItem = {
+    name: string;
+    key: COLORSIDS;
+    value: number | undefined;
+};
 interface IPieChartProps {
-    data: any;
-    labels?: any;
+    data: DataItem[];
+    labels?: unknown;
     compact?: boolean;
 }
 export enum COLORSIDS {
@@ -24,19 +31,17 @@ export class PieChartComponent extends React.PureComponent<IPieChartProps> {
         activeIndex: 0,
     };
 
-    onPieEnter = (data: any, index: number) => {
-        this.setState({
-            activeIndex: index,
-        });
-    };
-
     render(): JSX.Element {
         const { data } = this.props;
 
-        if (data.every(({ value }: any) => !value)) {
-            return <div className="empty-chart"><Trans i18nKey="noAssets"/></div>;
+        if (data.every(({ value }) => !value)) {
+            return (
+                <div className="empty-chart">
+                   {data.every(({ value }) => value === 0) ? <Trans i18nKey="noAssets"/> : <Skeleton width={40} />}
+                </div>
+            );
         }
-        const filteredData = data.filter(({ value }: any) => value !== 0);
+        const filteredData = data.filter(({ value }) => value !== 0);
 
         return (
             <div className="chart">
@@ -53,10 +58,10 @@ export class PieChartComponent extends React.PureComponent<IPieChartProps> {
                             label={false}
                             labelLine={false}
                         >
-                            {filteredData.map((entry: any) => (
+                            {filteredData.map((entry) => (
                                 <Cell
                                     key={`cell-${entry.value}`}
-                                    fill={COLORS[entry.key as COLORSIDS]}
+                                    fill={COLORS[entry.key]}
                                 />
                             ))}
                         </Pie>


### PR DESCRIPTION
Currently the `Personal Info` section shows `$0.00` for the different assets while the data is being loaded.  As the load can take a bit, it could concern users that their balance is missing.

This PR adds loading skeletons to the asset value amounts and hides the `"You don’t have any assets right now"` text in the pie chart until the values have actually loaded.
![Screenshot from 2021-09-25 01-15-57](https://user-images.githubusercontent.com/3629629/134759416-88ac48ac-78fe-4db8-b1c9-7569e1a46310.png)

It also hides the whole `Personal Info` section if a wallet is not connect (as there will never be meaningful info then)
![Screenshot from 2021-09-25 01-19-06](https://user-images.githubusercontent.com/3629629/134759433-8549ac7e-6bfc-44a4-9c10-0eff2db1f60f.png)
.
